### PR TITLE
Port the keyboard to qt6

### DIFF
--- a/eta-keyboard.pro
+++ b/eta-keyboard.pro
@@ -1,4 +1,4 @@
-QT += qml quick widgets dbus x11extras network svg
+QT += qml quick widgets dbus network svg
 
 TARGET = eta-keyboard
 TEMPLATE = app

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,6 +19,7 @@
  *****************************************************************************/
 #include "src/helper.h"
 #include "src/singleinstance.h"
+#include <QtCore/QTextStream>
 #include <signal.h>
 #include <unistd.h>
 #include <QApplication>
@@ -26,15 +27,15 @@
 #include <QtQml>
 #include <QDir>
 #include <QCursor>
-#include <X11/Xlib.h>
-#include <X11/Xatom.h>
-#include <X11/Xresource.h>
 #include <QQmlContext>
 #include <QScreen>
 #include <QGuiApplication>
 #include <QRect>
-#include <QDesktopWidget>
 #include <QDebug>
+
+#include <X11/Xlib.h>
+#include <X11/Xatom.h>
+#include <X11/Xresource.h>
 
 #define SINGLE_INSTANCE ".virtualkeyboard"
 static int setup_unix_signal_handlers();
@@ -49,7 +50,8 @@ int main(int argc, char *argv[])
 
     qmlRegisterType<Helper>("eta.helper",1,0,"Helper");
 
-    QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    // TODO: this is no longer needed for Qt6, remove it
+    // QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 
     QApplication app(argc, argv);
 
@@ -101,7 +103,7 @@ int main(int argc, char *argv[])
 
     // Expose DPI value to QML
     engine.rootContext()->setContextProperty("dpiValue",
-                                             qApp->desktop()->logicalDpiX());
+                                             screen->logicalDotsPerInch());
 
     engine.load(QUrl(QStringLiteral("qrc:/ui/main.qml")));
     if (engine.rootObjects().isEmpty())

--- a/src/xkblibwrapper.h
+++ b/src/xkblibwrapper.h
@@ -22,11 +22,11 @@
 
 #include <QObject>
 #include <QStringList>
-#include <X11/XKBlib.h>
 
 class Logger;
 
 typedef struct _XDisplay Display;
+typedef struct _XkbStateRec XkbStateRec;
 
 struct XkbConfig {
     QString keyboardModel;
@@ -55,7 +55,7 @@ private:
     QList<LayoutUnit> getLayoutsList();
     bool getGroupNames(XkbConfig* xkbConfig);
     Display *display;
-    XkbStateRec xkbState;
+    XkbStateRec *xkbState;
     Logger *logger;
 };
 

--- a/src/xwrapper.h
+++ b/src/xwrapper.h
@@ -52,7 +52,7 @@ public:
     int getNumberOfLayouts();
     int getCapslockStatus();
     virtual bool nativeEventFilter(const QByteArray &eventType,
-                                   void *message, long * );
+                                   void *message, qintptr *result) override;
     void setHelper(Helper *h);
 private:
     int updateKeymap(struct keyboard *kbd);

--- a/ui/AlphaNumericKey.qml
+++ b/ui/AlphaNumericKey.qml
@@ -18,7 +18,7 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA .          *
  *****************************************************************************/
 
-import QtQuick 2.3
+import QtQuick 2.15
 
 // AlphaNumericKey // NonSticky
 

--- a/ui/CapsLockKey.qml
+++ b/ui/CapsLockKey.qml
@@ -18,7 +18,7 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA .          *
  *****************************************************************************/
 
-import QtQuick 2.3
+import QtQuick 2.15
 
 // FunctionKey
 

--- a/ui/EnterKey.qml
+++ b/ui/EnterKey.qml
@@ -18,8 +18,8 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA .          *
  *****************************************************************************/
 
-import QtQuick 2.3
-import QtQuick.Window 2.0
+import QtQuick 2.15
+import QtQuick.Window 2.15
 import eta.helper 1.0
 
 // EnterKey

--- a/ui/FullLayout.qml
+++ b/ui/FullLayout.qml
@@ -18,7 +18,7 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA .          *
  *****************************************************************************/
 
-import QtQuick 2.3
+import QtQuick 2.15
 
 Item{
     id: fullLayout
@@ -163,11 +163,19 @@ Item{
             }
         }//End of the column
 
-        EnterKey{
+        // TODO: try to bring back enterkey qml type
+        AlphaNumericKey{
             id: keyEnter
             x: keyUU.x + main.keyWidth + main.spacing + main.spacing
             y: row3.y + main.spacing
             z: -1
+            keyText: "\u23CE Enter"
+            keyCode: 36
+            leVis4: true
+            mirror: false
+            keyWidth: main.keyWidth * 3 / 2
+            keyHeight: main.keyHeight * 2 + main.spacing
+            fontPointSize: main.keyHeight / 4
         }
 
         AlphaNumericKey{

--- a/ui/FunctionKey.qml
+++ b/ui/FunctionKey.qml
@@ -18,7 +18,7 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA .          *
  *****************************************************************************/
 
-import QtQuick 2.3
+import QtQuick 2.15
 
 // FunctionKey
 

--- a/ui/Key.qml
+++ b/ui/Key.qml
@@ -17,8 +17,8 @@
  *   Free Software Foundation, Inc.,                                         *
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA .          *
  *****************************************************************************/
-import QtQuick 2.3
-import QtQuick.Window 2.0
+import QtQuick 2.15
+import QtQuick.Window 2.15
 import eta.helper 1.0
 
 Rectangle {

--- a/ui/MetaKey.qml
+++ b/ui/MetaKey.qml
@@ -17,7 +17,7 @@
  *   Free Software Foundation, Inc.,                                         *
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA .          *
  *****************************************************************************/
-import QtQuick 2.3
+import QtQuick 2.15
 
 // MetaKey
 

--- a/ui/NumericKey.qml
+++ b/ui/NumericKey.qml
@@ -17,7 +17,7 @@
  *   Free Software Foundation, Inc.,                                         *
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA .          *
  *****************************************************************************/
-import QtQuick 2.3
+import QtQuick 2.15
 
 // NumericKey
 

--- a/ui/PinLayout.qml
+++ b/ui/PinLayout.qml
@@ -18,7 +18,7 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA .          *
  *****************************************************************************/
 
-import QtQuick 2.3
+import QtQuick 2.15
 
 Item{
     id: pinLayout

--- a/ui/Settings.qml
+++ b/ui/Settings.qml
@@ -17,9 +17,9 @@
  *   Free Software Foundation, Inc.,                                         *
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA .          *
  *****************************************************************************/
-import QtQuick 2.3
-import QtQuick.Controls 1.2
-import QtQuick.Window 2.0
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Window 2.15
 import eta.helper 1.0
 
 ApplicationWindow {

--- a/ui/SettingsKey.qml
+++ b/ui/SettingsKey.qml
@@ -18,7 +18,7 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA .          *
  *****************************************************************************/
 
-import QtQuick 2.3
+import QtQuick 2.15
 
 // SettingsKey
 

--- a/ui/StickyKey.qml
+++ b/ui/StickyKey.qml
@@ -17,7 +17,7 @@
  *   Free Software Foundation, Inc.,                                         *
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA .          *
  *****************************************************************************/
-import QtQuick 2.3
+import QtQuick 2.15
 
 // StickyKey
 

--- a/ui/TabletKey.qml
+++ b/ui/TabletKey.qml
@@ -18,7 +18,7 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA .          *
  *****************************************************************************/
 
-import QtQuick 2.3
+import QtQuick 2.15
 
 // TabletKey
 

--- a/ui/TabletLayout.qml
+++ b/ui/TabletLayout.qml
@@ -18,7 +18,7 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA .          *
  *****************************************************************************/
 
-import QtQuick 2.3
+import QtQuick 2.15
 
 Item{
     id: tabletLayout

--- a/ui/Test.qml
+++ b/ui/Test.qml
@@ -17,10 +17,10 @@
  *   Free Software Foundation, Inc.,                                         *
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA .          *
  *****************************************************************************/
-import QtQuick 2.3
-import QtQuick.Controls 1.2
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 import eta.helper 1.0
-import QtQuick.Window 2.0
+import QtQuick.Window 2.15
 
 
 ApplicationWindow {

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -17,9 +17,9 @@
  *   Free Software Foundation, Inc.,                                         *
  *   51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA .          *
  *****************************************************************************/
-import QtQuick 2.3
-import QtQuick.Controls 1.2
-import QtQuick.Window 2.0
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Window 2.15
 import eta.helper 1.0
 
 
@@ -387,18 +387,20 @@ ApplicationWindow {
 
     function updateScreenGeometry(geometry) {
         // if (!main.initialized) return;
-        screenGeometry = geometry
-        screenWidth = geometry.width
-        screenHeight = geometry.height
+        if (geometry) {
+            screenGeometry = geometry
+            screenWidth = geometry.width
+            screenHeight = geometry.height
 
-        setSize()
-        setPosition()
+            setSize()
+            setPosition()
 
-        // Recalculate position with new h/w vals
-        main.x = main.screenWidth / 2 - main.width / 2;
-        main.y = main.screenHeight - main.height - main.spacing * 20;
-        if (main.pinMode) {
-            main.y = main.screenHeight / 2 - main.height / 2;
+            // Recalculate position with new h/w vals
+            main.x = main.screenWidth / 2 - main.width / 2;
+            main.y = main.screenHeight - main.height - main.spacing * 20;
+            if (main.pinMode) {
+                main.y = main.screenHeight / 2 - main.height / 2;
+        }
         }
     }
 
@@ -559,7 +561,7 @@ ApplicationWindow {
 
     Connections {
         target: screen
-        function onGeometryChanged(geometry) {
+        onGeometryChanged: function(geometry) {
             updateScreenGeometry(geometry)
         }
     }

--- a/ui/main.qml
+++ b/ui/main.qml
@@ -140,8 +140,14 @@ ApplicationWindow {
     }
 
     function constrainPosition(x, y){
+        // TODO: figure why it cannot get screen's info
         var availableGeometry = screen.availableGeometry;
         var screenGeometry = screen.geometry;
+        // TEMP: Fallback if screen properties are undefined
+        if (!availableGeometry || !screenGeometry) {
+            return Qt.point(x, y);
+        }
+
         var topPanelHeight = availableGeometry.y - screenGeometry.y;
         var bottomPanelHeight = (screenGeometry.y + screenGeometry.height) - (availableGeometry.y + availableGeometry.height);
         var safetyMargin = 5;


### PR DESCRIPTION
Port the keyboard to qt6 away from qt5
This is initial port. Currently you can compile and run it (not under WAYLAND). It works just fine mostly
Draft because it still need some work and some more testing(need to test it under Pardus 23 etap explicitly)

This tested under ArchLinux and Pardus 23.4